### PR TITLE
Fix SSH connection leaks

### DIFF
--- a/src/main/java/com/sonyericsson/hudson/plugins/gerrit/trigger/config/GerritJcascConfigurator.java
+++ b/src/main/java/com/sonyericsson/hudson/plugins/gerrit/trigger/config/GerritJcascConfigurator.java
@@ -47,7 +47,6 @@ import java.util.Calendar;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.HashSet;
-import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import java.util.stream.Collectors;

--- a/src/main/java/com/sonyericsson/hudson/plugins/gerrit/trigger/config/GerritJcascConfigurator.java
+++ b/src/main/java/com/sonyericsson/hudson/plugins/gerrit/trigger/config/GerritJcascConfigurator.java
@@ -91,7 +91,12 @@ public class GerritJcascConfigurator extends BaseConfigurator<PluginImpl> {
     protected void configure(
         Mapping config, PluginImpl instance, boolean dryrun, ConfigurationContext context
     ) throws ConfiguratorException {
-        List<GerritServer> oldServers = new ArrayList<>(instance.getServers());
+        if (!dryrun) {
+            for (GerritServer oldServer : instance.getServers()) {
+                oldServer.stopConnection();
+                oldServer.stop();
+            }
+        }
 
         try {
             super.configure(config, instance, dryrun, context);
@@ -101,11 +106,6 @@ public class GerritJcascConfigurator extends BaseConfigurator<PluginImpl> {
 
         if (!dryrun) {
             instance.getPluginConfig().updateEventFilter();
-
-            for (GerritServer oldServer : oldServers) {
-                oldServer.stopConnection();
-                oldServer.stop();
-            }
 
             for (GerritServer server : instance.getServers()) {
                 server.getConfig().setNumberOfSendingWorkerThreads(


### PR DESCRIPTION
When the Configuration As Code changes the instances of GerritServer can be refreshed, before that we need to stop the server  to be sure the opened SSH connections are properly released.
Otherwise it is possible to create a 'zombie' SshConnection objects detached from the Gerrit Server and so never released.

This behavior was observed with our Gerrit Server version 2.14.2 and Jenkins Master 2.346.2. 